### PR TITLE
Auto encryption without server key and certificate.

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -299,7 +299,7 @@ EOF
   fi
 
   local rpc_encryption_configuration=""
-  if [[ "$enable_rpc_encryption" == "true" && ! -z "$ca_path" && ! -z "$cert_file_path" && ! -z "$key_file_path" ]]; then
+  if [[ "$enable_rpc_encryption" == "true" && ! -z "$ca_path" ]]; then
     log_info "Creating RPC encryption configuration"
     rpc_encryption_configuration=$(cat <<EOF
 "verify_outgoing": true,
@@ -307,15 +307,20 @@ EOF
 "verify_incoming_https": false,
 "verify_server_hostname": true,
 "enable_agent_tls_for_checks": true,
-"ca_path": "$ca_path",
-"cert_file": "$cert_file_path",
-"key_file": "$key_file_path",
 "ports": {
   "https": 8501,
   "grpc": 8502
 },
+"ca_path": "$ca_path",
 EOF
 )
+    if [[ ! -z "$cert_file_path" && ! -z "$key_file_path" ]]; then
+        rpc_encryption_configuration+=$(cat <<EOF
+"cert_file": "$cert_file_path",
+"key_file": "$key_file_path",
+EOF
+)
+    fi
   fi
 
   local auto_encrypt_configuration=""
@@ -669,8 +674,10 @@ function run {
     fi
     if [[ "$enable_rpc_encryption" == "true" ]]; then
       assert_not_empty "--ca-path" "$ca_path"
-      assert_not_empty "--cert-file-path" "$cert_file_path"
-      assert_not_empty "--key_file_path" "$key_file_path"
+      if [[ "$enable_auto_encryption" != "true" || "$server" = true ]]; then
+          assert_not_empty "--cert-file-path" "$cert_file_path"
+          assert_not_empty "--key-file-path" "$key_file_path"
+      fi
     fi
 
     generate_consul_config "$server" \

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -303,7 +303,6 @@ EOF
     log_info "Creating RPC encryption configuration"
     rpc_encryption_configuration=$(cat <<EOF
 "verify_outgoing": true,
-"verify_incoming": true,
 "verify_incoming_https": false,
 "verify_server_hostname": true,
 "enable_agent_tls_for_checks": true,
@@ -316,8 +315,14 @@ EOF
 )
     if [[ ! -z "$cert_file_path" && ! -z "$key_file_path" ]]; then
         rpc_encryption_configuration+=$(cat <<EOF
+"verify_incoming": true,
 "cert_file": "$cert_file_path",
 "key_file": "$key_file_path",
+EOF
+)
+    else
+        rpc_encryption_configuration+=$(cat <<EOF
+"verify_incoming": false,
 EOF
 )
     fi

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -336,7 +336,6 @@ EOF
     else
       log_info "Creating RPC auto_encrypt configuration for client"
       auto_encrypt_configuration=$(cat <<EOF
-"ca_file": "$ca_path",
 "auto_encrypt": {
     "tls": true
 },


### PR DESCRIPTION
Enable auto encryption without requiring server key and certificate. My understand of auto-encryption is that the server will provide a PKI certificate to clients, you don't have to distribute them yourself. Adjusted to create a configuration similar to on in the Learning Consul documentation.